### PR TITLE
Fix file headers and footer for ELPA compatibility

### DIFF
--- a/shampoo.el
+++ b/shampoo.el
@@ -1,10 +1,11 @@
-;;; shampoo.el --- Shampoo, a remote Smalltalk developemnt
-;;                 mode for GNU Emacs
+;;; shampoo.el --- A remote Smalltalk development mode
 ;;
 ;; Copyright (C) 2010 - 2012 Dmitry Matveev <me@dmitrymatveev.co.uk>
 ;;
 ;; This software is released under terms of the MIT license,
 ;; please refer to the LICENSE file for details.
+
+;;; Code:
 
 (eval-when-compile (require 'cl))
 (require 'shampoo-auth)
@@ -182,4 +183,4 @@
 
 (provide 'shampoo)
 
-;; shampoo.el ends here.
+;;; shampoo.el ends here.


### PR DESCRIPTION
These changes allow the `package-buffer-info` function to parse metadata out of the file.

(Hint: the built-in `auto-insert-mode` optionally inserts a compatible elisp skeleton whenever you create a new .el file)

See https://github.com/milkypostman/melpa/pull/1318

Cheers,

-Steve
