### PR TITLE
Elisp maintenance patches

### DIFF
--- a/shampoo.el
+++ b/shampoo.el
@@ -148,6 +148,7 @@
 (defun shampoo-handle-shutdown ()
   (message "Shampoo: connection terminated"))
 
+;;;###autoload
 (defun shampoo-connect (login-info)
   (interactive "sConnect to a Shampoo image: ")
   (let ((connect-info (shampoo-parse-login login-info)))

--- a/shampoo.el
+++ b/shampoo.el
@@ -1,9 +1,20 @@
 ;;; shampoo.el --- A remote Smalltalk development mode
-;;
+
 ;; Copyright (C) 2010 - 2012 Dmitry Matveev <me@dmitrymatveev.co.uk>
-;;
+;; SPDX-License-Identifier: MIT
+
+;; Author: Dmitry Matveev <me@dmitrymatveev.co.uk>
+;; URL: https://revival.sh/shampoo/
+;; Package-Requires: ((emacs "24.1"))
+;; Package-Version: 0.0.1
+;; Keywords: languages
+
 ;; This software is released under terms of the MIT license,
 ;; please refer to the LICENSE file for details.
+
+;;; Commentary:
+
+;; A set of tools for remote Smalltalk development with Emacs.
 
 ;;; Code:
 
@@ -90,7 +101,7 @@
         (goto-char (point-max))
         (insert (shampoo-response-enclosed-string resp))))))
 
-          
+
 (defun shampoo-handle-source-response (resp)
   (with-current-buffer (get-buffer-create "*shampoo-code*")
     (save-excursion
@@ -184,4 +195,4 @@
 
 (provide 'shampoo)
 
-;;; shampoo.el ends here.
+;;; shampoo.el ends here


### PR DESCRIPTION
Here are a few things to make the package adhere more closely to Emacs Lisp conventions.

Tools used:

* M-x package-lint (from MELPA)
* M-x checkdoc

Most significantly, added autoload so the `shampoo-connect` command is available before `require`ing the whole package.